### PR TITLE
Clean CreateBreps.cs

### DIFF
--- a/HoaryFox/HoaryFox.csproj
+++ b/HoaryFox/HoaryFox.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Member\FrameBreps.cs" />
     <Compile Include="Member\CreateTag.cs" />
     <Compile Include="Member\FramePoints.cs" />
+    <Compile Include="Member\ShapeInfo.cs" />
     <Compile Include="Member\SteelCroSecBrep.cs" />
     <Compile Include="STBReader\STBReader\Member\Base.cs" />
     <Compile Include="STBReader\STBReader\Member\Enum.cs" />

--- a/HoaryFox/Member/CreateBreps.cs
+++ b/HoaryFox/Member/CreateBreps.cs
@@ -9,34 +9,107 @@ namespace HoaryFox.Member
 {
     public static class CreateBreps
     {
-        public static IEnumerable<Brep> FromEndPoint(StbData stbData, Point3d nodeStart, Point3d nodeEnd, double height, double width, double rotate, ShapeTypes shapeType, FrameType frameType)
+        public static IEnumerable<Brep> FromEndPoint(StbData stbData, ShapeInfo shapeInfo, ShapeTypes shapeType, FrameType frameType)
         {
-            var pointStart = new Point3d[6];
-            var pointEnd = new Point3d[6];
+            Vector3d dVector = shapeInfo.NodeEnd - shapeInfo.NodeStart;
+            var angles = new List<double>
+            {
+                -1 * Math.Atan2(dVector.Y, dVector.X),
+                -1 * Math.Atan2(dVector.Z, dVector.X)
+            };
+
+            List<List<Point3d>> origins = GetOriginPoints(frameType, shapeInfo, angles);
+            List<Brep> breps = GetSecBrep(stbData, shapeType, origins, shapeInfo);
+            List<Brep> brepRot = ApplyRotation(breps, shapeInfo.Rotate, frameType, origins);
+            return brepRot;
+        }
+
+        private static List<Brep> ApplyRotation(List<Brep> breps, double rotate, FrameType frameType, List<List<Point3d>> origins)
+        {
+            if (rotate == 0d)
+            {
+                return breps;
+            }
+            
+            double rotateAngle = rotate * Math.PI / 180d;
+            var rotationCenter = new Point3d[2];
+            if (frameType == FrameType.Girder || frameType == FrameType.Beam)
+            {
+                rotationCenter[0] = new Point3d(origins[0][4]);
+                rotationCenter[1] = new Point3d(origins[0][4]);
+            }
+            else
+            {
+                rotationCenter[0] = new Point3d(
+                    (origins[0][1].X + origins[0][4].X) / 2, (origins[0][1].Y + origins[0][4].Y) / 2, (origins[0][1].Z + origins[0][4].Z) / 2
+                );
+                rotationCenter[1] = new Point3d(
+                    (origins[1][1].X + origins[1][4].X) / 2, (origins[1][1].Y + origins[1][4].Y) / 2, (origins[1][1].Z + origins[1][4].Z) / 2
+                );
+            }
+            var rotationAxis = new Vector3d(rotationCenter[1] - rotationCenter[0]);
+            foreach (Brep b in breps)
+            {
+                b.Rotate(rotateAngle, rotationAxis, rotationCenter[0]);
+            }
+
+            return breps;
+        }
+
+        private static List<Brep> GetSecBrep(StbData stbData, ShapeTypes shapeType, List<List<Point3d>> origins, ShapeInfo shapeInfo)
+        {
             List<Brep> brep;
+            var secBrep = new SteelCroSecBrep(stbData, origins);
+            switch (shapeType)
+            {
+                case ShapeTypes.H:
+                    brep = secBrep.HShape();
+                    break;
+                case ShapeTypes.BOX:
+                case ShapeTypes.BuildBOX:
+                case ShapeTypes.RollBOX:
+                case ShapeTypes.FB:
+                    brep = secBrep.BoxShape();
+                    break;
+                case ShapeTypes.Bar:
+                case ShapeTypes.Pipe:
+                    brep = secBrep.PipeShape(shapeInfo);
+                    break;
+                case ShapeTypes.L:
+                    brep = secBrep.LShape();
+                    break;
+                case ShapeTypes.T:
+                    brep = secBrep.TShape();
+                    break;
+                case ShapeTypes.C:
+                    brep = secBrep.CShape();
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(shapeType), shapeType, null);
+            }
 
-            double dx = nodeEnd.X - nodeStart.X;
-            double dy = nodeEnd.Y - nodeStart.Y;
-            double dz = nodeEnd.Z - nodeStart.Z;
-            double angleY = -1 * Math.Atan2(dy, dx);
-            double angleZ = -1 * Math.Atan2(dz, dx);
+            return brep;
+        }
 
+        private static List<List<Point3d>> GetOriginPoints(FrameType frameType, ShapeInfo shapeInfo, IReadOnlyList<double> angles)
+        {
+            var origin = new List<List<Point3d>>();
             // 梁は部材天端の中心が起点に対して、柱・ブレースは部材芯が起点なので場合分け
             switch (frameType)
             {
                 case FrameType.Column:
                 case FrameType.Post:
-                    pointStart = FramePoints.Column(nodeStart, width, height, angleZ);
-                    pointEnd = FramePoints.Column(nodeEnd, width, height, angleZ);
+                    origin.Add(FramePoints.Column(shapeInfo.NodeStart, shapeInfo.Width, shapeInfo.Height, angles[1]));
+                    origin.Add(FramePoints.Column(shapeInfo.NodeEnd, shapeInfo.Width, shapeInfo.Height, angles[1]));
                     break;
                 case FrameType.Girder:
                 case FrameType.Beam:
-                    pointStart = FramePoints.Girder(nodeStart, width, height, angleY);
-                    pointEnd = FramePoints.Girder(nodeEnd, width, height, angleY);
+                    origin.Add(FramePoints.Girder(shapeInfo.NodeStart, shapeInfo.Width, shapeInfo.Height, angles[0]));
+                    origin.Add(FramePoints.Girder(shapeInfo.NodeEnd, shapeInfo.Width, shapeInfo.Height, angles[0]));
                     break;
                 case FrameType.Brace:
-                    pointStart = FramePoints.Brace(nodeStart, width, angleY);
-                    pointEnd = FramePoints.Brace(nodeEnd, width, angleY);
+                    origin.Add(FramePoints.Brace(shapeInfo.NodeStart, shapeInfo.Width, angles[0]));
+                    origin.Add(FramePoints.Brace(shapeInfo.NodeEnd, shapeInfo.Width, angles[0]));
                     break;
                 case FrameType.Slab:
                 case FrameType.Wall:
@@ -46,59 +119,9 @@ namespace HoaryFox.Member
                     throw new ArgumentOutOfRangeException(nameof(frameType), frameType, null);
             }
 
-            var secBrep = new SteelCroSecBrep(stbData);
-            switch (shapeType)
-            {
-                case ShapeTypes.H:
-                    brep = secBrep.HShape(pointStart, pointEnd);
-                    break;
-                case ShapeTypes.BOX:
-                case ShapeTypes.BuildBOX:
-                case ShapeTypes.RollBOX:
-                case ShapeTypes.FB:
-                    brep = secBrep.BoxShape(pointStart, pointEnd);
-                    break;
-                case ShapeTypes.Bar:
-                case ShapeTypes.Pipe:
-                    brep = secBrep.PipeShape(nodeStart, nodeEnd, width);
-                    break;
-                case ShapeTypes.L:
-                    brep = secBrep.LShape(pointStart, pointEnd);
-                    break;
-                case ShapeTypes.T:
-                    brep = secBrep.TShape(pointStart, pointEnd);
-                    break;
-                case ShapeTypes.C:
-                    brep = secBrep.CShape(pointStart, pointEnd);
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(shapeType), shapeType, null);
-            }
-
-            double rotateAngle = rotate * Math.PI / 180d;
-            var rotationCenter = new Point3d[2];
-            if (frameType == FrameType.Girder || frameType == FrameType.Beam)
-            {
-                rotationCenter[0] = new Point3d(pointStart[4]);
-                rotationCenter[1] = new Point3d(pointStart[4]);
-            }
-            else
-            {
-                rotationCenter[0] = new Point3d(
-                    (pointStart[1].X + pointStart[4].X) / 2, (pointStart[1].Y + pointStart[4].Y) / 2, (pointStart[1].Z + pointStart[4].Z) / 2
-                );
-                rotationCenter[1] = new Point3d(
-                    (pointEnd[1].X + pointEnd[4].X) / 2, (pointEnd[1].Y + pointEnd[4].Y) / 2, (pointEnd[1].Z + pointEnd[4].Z) / 2
-                );
-            }
-            var rotationAxis = new Vector3d(rotationCenter[1] - rotationCenter[0]);
-            foreach (Brep b in brep)
-            {
-                b.Rotate(rotateAngle, rotationAxis, rotationCenter[0]);
-            }
-            return brep;
+            return origin;
         }
-        
+
 
         public static Brep PlaneWithOpens(StbData stbData, Point3d[] pts, StbOpen open)
         {
@@ -107,41 +130,24 @@ namespace HoaryFox.Member
             
             try
             {
-                var centerPt = new Point3d();
-
-                switch (pts.Length)
-                {
-                    case 3:
-                        brep = Brep.CreateFromCornerPoints(pts[0], pts[1], pts[2], tol);
-                        break;
-                    case 4:
-                        brep = Brep.CreateFromCornerPoints(pts[0], pts[1], pts[2], pts[3], tol);
-                        break;
-                    default:
-                        foreach (Point3d pt in pts)
-                        {
-                            centerPt.X += pt.X / pts.Length;
-                            centerPt.Y += pt.Y / pts.Length;
-                            centerPt.Z += pt.Z / pts.Length;
-                        }
-                        brep = Brep.CreateFromCornerPoints(pts[0], pts[1], centerPt, tol);
-                        for (var i = 0; i < pts.Length - 2; i++)
-                        {
-                            brep.Join(Brep.CreateFromCornerPoints(pts[i + 1], pts[i + 2], centerPt, tol), tol, false);
-                        }
-                        brep.Join(Brep.CreateFromCornerPoints(pts[pts.Length - 1], pts[0], centerPt, tol), tol, true);
-                        break;
-                }
+                brep =  CreatePlaneBreps(pts, tol);
             }
             catch(NullReferenceException)
             {
                 brep = null;
             }
+            
+            Brep planeWithOpens = ApplyOpens(brep, pts, open, tol);
 
-            Brep planeBrep = brep;
-            if (open == null || pts.Length != 4 || open.Id.Count == 0 || brep == null)
+            return planeWithOpens;
+        }
+
+        private static Brep ApplyOpens(Brep brep, IReadOnlyCollection<Point3d> pts, StbOpen open, double tol)
+        {
+            Brep planeWithOpens = brep;
+            if (open == null || pts.Count != 4 || open.Id.Count == 0 || brep == null)
             {
-                return planeBrep;
+                return planeWithOpens;
             }
             
             Surface surface = brep.Surfaces[0];
@@ -151,20 +157,45 @@ namespace HoaryFox.Member
             {
                 for (var i = 0; i < open.Id.Count; i++)
                 {
-                    // TODO:いつトリムが失敗するか調べる
                     var intervalX = new Interval(open.PositionX[i], open.PositionX[i] + open.LengthX[i]);
                     var intervalY = new Interval(open.PositionY[i], open.PositionY[i] + open.LengthY[i]);
                     trimSurf.Add(surface.Trim(intervalX, intervalY).ToBrep());
                 }
-                planeBrep = Brep.CreateBooleanDifference(new[]{ brep }, trimSurf, tol)[0];
+                planeWithOpens = Brep.CreateBooleanDifference(new[]{ brep }, trimSurf, tol)[0];
             }
             catch (NullReferenceException)
             {
-                planeBrep = brep;
+                planeWithOpens = brep;
             }
 
-            return planeBrep;
+            return planeWithOpens;
         }
 
+        private static Brep CreatePlaneBreps(IReadOnlyList<Point3d> pts, double tol)
+        {
+            switch (pts.Count)
+            {
+                case 3:
+                    return Brep.CreateFromCornerPoints(pts[0], pts[1], pts[2], tol);
+                case 4:
+                    return Brep.CreateFromCornerPoints(pts[0], pts[1], pts[2], pts[3], tol);
+                default:
+                    var centerPt = new Point3d();
+
+                    foreach (Point3d pt in pts)
+                    {
+                        centerPt.X += pt.X / pts.Count;
+                        centerPt.Y += pt.Y / pts.Count;
+                        centerPt.Z += pt.Z / pts.Count;
+                    }
+                    var brep = Brep.CreateFromCornerPoints(pts[0], pts[1], centerPt, tol);
+                    for (var i = 0; i < pts.Count - 2; i++)
+                    {
+                        brep.Join(Brep.CreateFromCornerPoints(pts[i + 1], pts[i + 2], centerPt, tol), tol, false);
+                    }
+                    brep.Join(Brep.CreateFromCornerPoints(pts[pts.Count - 1], pts[0], centerPt, tol), tol, true);
+                    return brep;
+            }
+        }
     }
 }

--- a/HoaryFox/Member/CreateBreps.cs
+++ b/HoaryFox/Member/CreateBreps.cs
@@ -26,11 +26,6 @@ namespace HoaryFox.Member
 
         private static List<Brep> ApplyRotation(List<Brep> breps, double rotate, FrameType frameType, List<List<Point3d>> origins)
         {
-            if (rotate == 0d)
-            {
-                return breps;
-            }
-            
             double rotateAngle = rotate * Math.PI / 180d;
             var rotationCenter = new Point3d[2];
             if (frameType == FrameType.Girder || frameType == FrameType.Beam)

--- a/HoaryFox/Member/FrameBreps.cs
+++ b/HoaryFox/Member/FrameBreps.cs
@@ -164,22 +164,4 @@ namespace HoaryFox.Member
             return brep;
         }
     }
-        
-    public struct ShapeInfo
-    {
-        public Point3d NodeStart { get; }
-        public Point3d NodeEnd { get; }
-        public double Height { get; }
-        public double Width { get; }
-        public double Rotate { get; }
-        
-        public ShapeInfo(Point3d nodeStart, Point3d nodeEnd, double height, double width, double rotate)
-        {
-            NodeStart = nodeStart;
-            NodeEnd = nodeEnd;
-            Height = height;
-            Width = width;
-            Rotate = rotate;
-        }
-    }
 }

--- a/HoaryFox/Member/FrameBreps.cs
+++ b/HoaryFox/Member/FrameBreps.cs
@@ -156,11 +156,30 @@ namespace HoaryFox.Member
                     default:
                         throw new ArgumentOutOfRangeException();
                 }
-
-                brep.AddRange(CreateBreps.FromEndPoint(_stbData, nodeStart, nodeEnd, height, width, rotate, shapeType,  frameData.FrameType));
+                
+                var shapeInfo = new ShapeInfo(nodeStart, nodeEnd, height, width, rotate);
+                brep.AddRange(CreateBreps.FromEndPoint(_stbData, shapeInfo, shapeType, frameData.FrameType));
             }
 
             return brep;
+        }
+    }
+        
+    public struct ShapeInfo
+    {
+        public Point3d NodeStart { get; }
+        public Point3d NodeEnd { get; }
+        public double Height { get; }
+        public double Width { get; }
+        public double Rotate { get; }
+        
+        public ShapeInfo(Point3d nodeStart, Point3d nodeEnd, double height, double width, double rotate)
+        {
+            NodeStart = nodeStart;
+            NodeEnd = nodeEnd;
+            Height = height;
+            Width = width;
+            Rotate = rotate;
         }
     }
 }

--- a/HoaryFox/Member/FramePoints.cs
+++ b/HoaryFox/Member/FramePoints.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Rhino.Geometry;
 
 namespace HoaryFox.Member
@@ -8,81 +9,48 @@ namespace HoaryFox.Member
         //  Y        3 - 4 - 5 
         //  ^        |   |   |  
         //  o >  X   0 - 1 - 2
-        public static Point3d[] Column(Point3d node, double width, double height, double angle)
+        public static List<Point3d> Column(Point3d node, double width, double height, double angle)
         {
-            var points = new Point3d[6];
-
-            points[0] = new Point3d(node.X - width / 2 * Math.Sin(angle),
-                                    node.Y - height / 2,
-                                    node.Z - width / 2 * Math.Cos(angle));
-            points[1] = new Point3d(node.X,
-                                    node.Y + height / 2,
-                                    node.Z);
-            points[2] = new Point3d(node.X + width / 2 * Math.Sin(angle),
-                                    node.Y - height / 2,
-                                    node.Z + width / 2 * Math.Cos(angle));
-            points[3] = new Point3d(node.X - width / 2 * Math.Sin(angle),
-                                    node.Y + height / 2,
-                                    node.Z - width / 2 * Math.Cos(angle));
-            points[4] =  new Point3d(node.X,
-                                     node.Y - height / 2,
-                                     node.Z);
-            points[5] = new Point3d(node.X + width / 2 * Math.Sin(angle),
-                                    node.Y + height / 2,
-                                    node.Z + width / 2 * Math.Cos(angle));
+            var points = new List<Point3d>
+            {
+                new Point3d(node.X - width / 2 * Math.Sin(angle), node.Y - height / 2, node.Z - width / 2 * Math.Cos(angle)),
+                new Point3d(node.X, node.Y + height / 2, node.Z),
+                new Point3d(node.X + width / 2 * Math.Sin(angle), node.Y - height / 2, node.Z + width / 2 * Math.Cos(angle)),
+                new Point3d(node.X - width / 2 * Math.Sin(angle), node.Y + height / 2, node.Z - width / 2 * Math.Cos(angle)),
+                new Point3d(node.X, node.Y - height / 2, node.Z),
+                new Point3d(node.X + width / 2 * Math.Sin(angle), node.Y + height / 2, node.Z + width / 2 * Math.Cos(angle))
+            };
             
             return points;
         }
 
-        public static Point3d[] Girder(Point3d node, double width, double height, double angle)
+        public static List<Point3d> Girder(Point3d node, double width, double height, double angle)
         {
-            var points = new Point3d[6];
+            var points = new List<Point3d>
+            {
+                new Point3d(node.X + width / 2 * Math.Sin(angle), node.Y + width / 2 * Math.Cos(angle), node.Z - height),
+                new Point3d(node.X, node.Y, node.Z - height),
+                new Point3d(node.X - width / 2 * Math.Sin(angle), node.Y - width / 2 * Math.Cos(angle), node.Z - height),
+                new Point3d(node.X + width / 2 * Math.Sin(angle), node.Y + width / 2 * Math.Cos(angle), node.Z),
+                new Point3d(node.X, node.Y, node.Z),
+                new Point3d(node.X - width / 2 * Math.Sin(angle), node.Y - width / 2 * Math.Cos(angle), node.Z)
+            };
 
-            points[0] = new Point3d(node.X + width / 2 * Math.Sin(angle),
-                                    node.Y + width / 2 * Math.Cos(angle),
-                                    node.Z - height);
-            points[1] = new Point3d(node.X,
-                                    node.Y,
-                                    node.Z - height);
-            points[2] = new Point3d(node.X - width / 2 * Math.Sin(angle),
-                                    node.Y - width / 2 * Math.Cos(angle),
-                                    node.Z - height);
-            points[3] = new Point3d(node.X + width / 2 * Math.Sin(angle),
-                                    node.Y + width / 2 * Math.Cos(angle),
-                                    node.Z);
-            points[4] = new Point3d(node.X,
-                                    node.Y,
-                                    node.Z);
-            points[5] = new Point3d(node.X - width / 2 * Math.Sin(angle),
-                                    node.Y - width / 2 * Math.Cos(angle),
-                                    node.Z);
-            
             return points;
         }
 
-        public static Point3d[] Brace(Point3d node, double width, double angle)
+        public static List<Point3d> Brace(Point3d node, double width, double angle)
         {
-            var points = new Point3d[6];
+            var points = new List<Point3d>
+            {
+                new Point3d(node.X + width / 2 * Math.Sin(angle), node.Y + width / 2 * Math.Cos(angle), node.Z - width / 2),
+                new Point3d(node.X, node.Y, node.Z - width / 2),
+                new Point3d(node.X - width / 2 * Math.Sin(angle), node.Y - width / 2 * Math.Cos(angle), node.Z - width / 2),
+                new Point3d(node.X + width / 2 * Math.Sin(angle), node.Y + width / 2 * Math.Cos(angle), node.Z + width / 2),
+                new Point3d(node.X, node.Y, node.Z + width / 2),
+                new Point3d(node.X - width / 2 * Math.Sin(angle), node.Y - width / 2 * Math.Cos(angle), node.Z + width / 2)
+            };
 
-            points[0] = new Point3d(node.X + width / 2 * Math.Sin(angle),
-                                    node.Y + width / 2 * Math.Cos(angle),
-                                    node.Z - width / 2);
-            points[1] = new Point3d(node.X,
-                                    node.Y,
-                                    node.Z - width / 2);
-            points[2] = new Point3d(node.X - width / 2 * Math.Sin(angle),
-                                    node.Y - width / 2 * Math.Cos(angle),
-                                    node.Z - width / 2);
-            points[3] = new Point3d(node.X + width / 2 * Math.Sin(angle),
-                                    node.Y + width / 2 * Math.Cos(angle),
-                                    node.Z + width / 2);
-            points[4] = new Point3d(node.X,
-                                    node.Y,
-                                    node.Z + width / 2);
-            points[5] = new Point3d(node.X - width / 2 * Math.Sin(angle),
-                                    node.Y - width / 2 * Math.Cos(angle),
-                                    node.Z + width / 2);
-            
             return points;
         }
     }

--- a/HoaryFox/Member/ShapeInfo.cs
+++ b/HoaryFox/Member/ShapeInfo.cs
@@ -1,0 +1,46 @@
+using System;
+using Rhino.Geometry;
+
+namespace HoaryFox.Member
+{
+    public readonly struct ShapeInfo : IEquatable<ShapeInfo>
+    {
+        public Point3d NodeStart { get; }
+        public Point3d NodeEnd { get; }
+        public double Height { get; }
+        public double Width { get; }
+        public double Rotate { get; }
+        
+        public ShapeInfo(Point3d nodeStart, Point3d nodeEnd, double height, double width, double rotate)
+        {
+            NodeStart = nodeStart;
+            NodeEnd = nodeEnd;
+            Height = height;
+            Width = width;
+            Rotate = rotate;
+        }
+
+        public bool Equals(ShapeInfo other)
+        {
+            return NodeStart.Equals(other.NodeStart) && NodeEnd.Equals(other.NodeEnd) && Height.Equals(other.Height) && Width.Equals(other.Width) && Rotate.Equals(other.Rotate);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is ShapeInfo other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hashCode = NodeStart.GetHashCode();
+                hashCode = (hashCode * 397) ^ NodeEnd.GetHashCode();
+                hashCode = (hashCode * 397) ^ Height.GetHashCode();
+                hashCode = (hashCode * 397) ^ Width.GetHashCode();
+                hashCode = (hashCode * 397) ^ Rotate.GetHashCode();
+                return hashCode;
+            }
+        }
+    }
+}

--- a/HoaryFox/Member/SteelCroSecBrep.cs
+++ b/HoaryFox/Member/SteelCroSecBrep.cs
@@ -7,70 +7,74 @@ namespace HoaryFox.Member
     public class SteelCroSecBrep
     {
         private readonly StbData _stbData;
+        private readonly List<Point3d> _pointStart;
+        private readonly List<Point3d> _pointEnd;
 
-        public SteelCroSecBrep(StbData stbData)
+        public SteelCroSecBrep(StbData stbData, List<List<Point3d>> origins)
         {
             _stbData = stbData;
+            _pointStart = origins[0];
+            _pointEnd = origins[1];
         }
         
-        public List<Brep> CShape(Point3d[] pointStart, Point3d[] pointEnd)
+        public List<Brep> CShape()
         {
             var brep = new List<Brep>
             {
-                Brep.CreateFromCornerPoints(pointStart[3], pointStart[4], pointEnd[5], pointEnd[4], _stbData.ToleLength),
-                Brep.CreateFromCornerPoints(pointStart[0], pointStart[1], pointEnd[1], pointEnd[0], _stbData.ToleLength),
-                Brep.CreateFromCornerPoints(pointStart[4], pointStart[1], pointEnd[1], pointEnd[4], _stbData.ToleLength)
+                Brep.CreateFromCornerPoints(_pointStart[3], _pointStart[4], _pointEnd[5], _pointEnd[4], _stbData.ToleLength),
+                Brep.CreateFromCornerPoints(_pointStart[0], _pointStart[1], _pointEnd[1], _pointEnd[0], _stbData.ToleLength),
+                Brep.CreateFromCornerPoints(_pointStart[4], _pointStart[1], _pointEnd[1], _pointEnd[4], _stbData.ToleLength)
             };
             return brep;
         }
 
-        public List<Brep> TShape(Point3d[] pointStart, Point3d[] pointEnd)
+        public List<Brep> TShape()
         {
             var brep = new List<Brep>
             {
-                Brep.CreateFromCornerPoints(pointStart[3], pointStart[5], pointEnd[5], pointEnd[3], _stbData.ToleLength),
-                Brep.CreateFromCornerPoints(pointStart[4], pointStart[1], pointEnd[1], pointEnd[4], _stbData.ToleLength)
+                Brep.CreateFromCornerPoints(_pointStart[3], _pointStart[5], _pointEnd[5], _pointEnd[3], _stbData.ToleLength),
+                Brep.CreateFromCornerPoints(_pointStart[4], _pointStart[1], _pointEnd[1], _pointEnd[4], _stbData.ToleLength)
             };
             return brep;
         }
 
-        public List<Brep> HShape(Point3d[] pointStart, Point3d[] pointEnd)
+        public List<Brep> HShape()
         {
             var brep = new List<Brep>
             {
-                Brep.CreateFromCornerPoints(pointStart[3], pointStart[5], pointEnd[5], pointEnd[3], _stbData.ToleLength),
-                Brep.CreateFromCornerPoints(pointStart[0], pointStart[2], pointEnd[2], pointEnd[0], _stbData.ToleLength),
-                Brep.CreateFromCornerPoints(pointStart[4], pointStart[1], pointEnd[1], pointEnd[4], _stbData.ToleLength)
+                Brep.CreateFromCornerPoints(_pointStart[3], _pointStart[5], _pointEnd[5], _pointEnd[3], _stbData.ToleLength),
+                Brep.CreateFromCornerPoints(_pointStart[0], _pointStart[2], _pointEnd[2], _pointEnd[0], _stbData.ToleLength),
+                Brep.CreateFromCornerPoints(_pointStart[4], _pointStart[1], _pointEnd[1], _pointEnd[4], _stbData.ToleLength)
             };
             return brep;
         }
 
-        public List<Brep> BoxShape(Point3d[] pointStart, Point3d[] pointEnd)
+        public List<Brep> BoxShape()
         {
             var brep = new List<Brep>
             {
-                Brep.CreateFromCornerPoints(pointStart[3], pointStart[5], pointEnd[5], pointEnd[3], _stbData.ToleLength),
-                Brep.CreateFromCornerPoints(pointStart[0], pointStart[2], pointEnd[2], pointEnd[0], _stbData.ToleLength),
-                Brep.CreateFromCornerPoints(pointStart[3], pointStart[0], pointEnd[0], pointEnd[3], _stbData.ToleLength),
-                Brep.CreateFromCornerPoints(pointStart[5], pointStart[2], pointEnd[2], pointEnd[5], _stbData.ToleLength)
+                Brep.CreateFromCornerPoints(_pointStart[3], _pointStart[5], _pointEnd[5], _pointEnd[3], _stbData.ToleLength),
+                Brep.CreateFromCornerPoints(_pointStart[0], _pointStart[2], _pointEnd[2], _pointEnd[0], _stbData.ToleLength),
+                Brep.CreateFromCornerPoints(_pointStart[3], _pointStart[0], _pointEnd[0], _pointEnd[3], _stbData.ToleLength),
+                Brep.CreateFromCornerPoints(_pointStart[5], _pointStart[2], _pointEnd[2], _pointEnd[5], _stbData.ToleLength)
             };
             return brep;
         }
 
-        public List<Brep> LShape(Point3d[] pointStart, Point3d[] pointEnd)
+        public List<Brep> LShape()
         {
             var brep = new List<Brep>
             {
-                Brep.CreateFromCornerPoints(pointStart[0], pointStart[2], pointEnd[2], pointEnd[0], _stbData.ToleLength),
-                Brep.CreateFromCornerPoints(pointStart[5], pointStart[2], pointEnd[2], pointEnd[5], _stbData.ToleLength)
+                Brep.CreateFromCornerPoints(_pointStart[0], _pointStart[2], _pointEnd[2], _pointEnd[0], _stbData.ToleLength),
+                Brep.CreateFromCornerPoints(_pointStart[5], _pointStart[2], _pointEnd[2], _pointEnd[5], _stbData.ToleLength)
             };
             return brep;
         }
 
-        public List<Brep> PipeShape(Point3d nodeStart, Point3d nodeEnd, double width)
+        public List<Brep> PipeShape(ShapeInfo shapeInfo)
         {
             var brep = new List<Brep>();            
-            brep.AddRange(Brep.CreatePipe(new LineCurve(nodeStart, nodeEnd), width / 2, true, PipeCapMode.Flat, true, _stbData.ToleLength, _stbData.ToleAngle));
+            brep.AddRange(Brep.CreatePipe(new LineCurve(shapeInfo.NodeStart, shapeInfo.NodeEnd), shapeInfo.Width / 2, true, PipeCapMode.Flat, true, _stbData.ToleLength, _stbData.ToleAngle));
             return brep;
         }
     }


### PR DESCRIPTION
## 変更点

- CreateBreps は大量の引数で呼ばれていたので、その情報を扱う構造体 ShapeInfo を作成して、可読性をあげた
- 各処理を分解して、メソッドを短くした

## 対応するIssue番号

close #
