### PR TITLE
Fix convert deck & precast slab to brep error

### DIFF
--- a/HoaryFox/Component/Utils/Geometry/BrepMaker/Slab.cs
+++ b/HoaryFox/Component/Utils/Geometry/BrepMaker/Slab.cs
@@ -25,22 +25,18 @@ namespace HoaryFox.Component.Utils.Geometry.BrepMaker
                             depth = tapers.First(sec => sec.pos == StbSecSlab_RC_TaperPos.TIP).depth;
                             break;
                         case 3:
-                            var haunches = new[]
-                            {
-                                slabRc[0] as StbSecSlab_RC_Haunch, slabRc[1] as StbSecSlab_RC_Haunch,
-                                slabRc[2] as StbSecSlab_RC_Haunch
-                            };
+                            var haunches = new[] { slabRc[0] as StbSecSlab_RC_Haunch, slabRc[1] as StbSecSlab_RC_Haunch, slabRc[2] as StbSecSlab_RC_Haunch };
                             depth = haunches.First(sec => sec.pos == StbSecSlab_RC_HaunchPos.CENTER).depth;
                             break;
                     }
 
                     break;
                 case StbSlabKind_structure.DECK:
-                // StbSecSlabDeck slabDeck = _sections.StbSecSlabDeck.FirstOrDefault(sec => sec.id == slab.id_section);
-                // break;
+                    depth = sections.StbSecSlabDeck.FirstOrDefault(sec => sec.id == slab.id_section).StbSecFigureSlabDeck.StbSecSlabDeckStraight.depth;
+                    break;
                 case StbSlabKind_structure.PRECAST:
-                // StbSecSlabPrecast slabPrecast = _sections.StbSecSlabPrecast.FirstOrDefault(sec => sec.id == slab.id_section);
-                // break;
+                    depth = sections.StbSecSlabPrecast.FirstOrDefault(sec => sec.id == slab.id_section).StbSecFigureSlabPrecast.StbSecSlabPrecastStraight.depth_concrete;
+                    break;
                 default:
                     throw new ArgumentOutOfRangeException();
             }

--- a/HoaryFox/Component/Utils/TagUtils.cs
+++ b/HoaryFox/Component/Utils/TagUtils.cs
@@ -120,6 +120,9 @@ namespace HoaryFox.Component.Utils
             var ghSecStrings = new GH_Structure<GH_String>();
             switch (steelFigure)
             {
+                case StbSecSteelBeam_S_Joint figure:
+                    ghSecStrings.Append(new GH_String(figure.pos + ":" + figure.shape + "(" + figure.strength_main + ")"));
+                    break;
                 case StbSecSteelBeam_S_Haunch figure:
                     ghSecStrings.Append(new GH_String(figure.pos + ":" + figure.shape + "(" + figure.strength_main + ")"));
                     break;
@@ -131,6 +134,9 @@ namespace HoaryFox.Component.Utils
                     break;
                 case StbSecSteelBeam_S_Straight figure:
                     ghSecStrings.Append(new GH_String(figure.shape + "(" + figure.strength_main + ")"));
+                    break;
+                case StbSecSteelBeam_SRC_Joint figure:
+                    ghSecStrings.Append(new GH_String(figure.pos + ":" + figure.shape + "(" + figure.strength_main + ")"));
                     break;
                 case StbSecSteelBeam_SRC_Haunch figure:
                     ghSecStrings.Append(new GH_String(figure.pos + ":" + figure.shape + "(" + figure.strength_main + ")"));
@@ -420,7 +426,13 @@ namespace HoaryFox.Component.Utils
                             }
                             break;
                         case "DECK":
+                            StbSecSlabDeck slabDeck = sections.StbSecSlabDeck.First(sec => sec.id == pDict["id_section"]);
+                            var deckFigure = slabDeck.StbSecFigureSlabDeck.StbSecSlabDeckStraight;
+                            sectionInfo.AddRange(GetSlabDeckSection(deckFigure, slabDeck.strength_concrete).ToList());
+                            break;
                         case "PRECAST":
+                            StbSecSlabPrecast slabPrecast = sections.StbSecSlabPrecast.First(sec => sec.id == pDict["id_section"]);
+                            sectionInfo.AddRange(GetSlabPrecastSection(slabPrecast.precast_type, slabPrecast.StbSecProductSlabPrecast, slabPrecast.strength_concrete).ToList());
                             break;
                     }
                     break;


### PR DESCRIPTION
## 変更点

- デッキスラブとプレキャストスラブをBrep化する部分が書かれていなかったので修正した。
  - 同様に断面情報を取得する部分も書かれていなかったので追加
  - これに合わせて、 #193 で上げた断面情報取得していない部分も修正

## 対応するIssue番号

close #193
close #194 
